### PR TITLE
CyclopPlusPlus: - ensure to call updateSoftPositions in ReadEEPROM - …

### DIFF
--- a/src/cyclop_plus_plus/cyclop_plus_plus.ino
+++ b/src/cyclop_plus_plus/cyclop_plus_plus.ino
@@ -388,6 +388,7 @@ bool readEeprom(void) {
   currentChannel =   EEPROM.read(EEPROM_CHANNEL);
   for (i = 0; i < MAX_OPTIONS; i++)
     options[i] = EEPROM.read(EEPROM_OPTIONS + i);
+  updateSoftPositions();
   return true;
 }
 


### PR DESCRIPTION
…fixes non-applied soft positions after power on.

As the title says. Soft positions are currently only applied when going into the options menu. I think they should be obeyed after power on aswell. (this is untested because i haven't time yet to unmount everything again to flash the controller - but i am 99% sure this is correct [tm] ).