### PR TITLE
Add display offset

### DIFF
--- a/src/cyclop_plus_plus/cyclop_plus_plus.h
+++ b/src/cyclop_plus_plus/cyclop_plus_plus.h
@@ -144,6 +144,6 @@
 // Release information
 #define VER_DATE_STRING           "2017-03-13"
 #define VER_INFO_STRING           "v2.3 by Dvogonen"
-#define VER_EEPROM                241
+#define VER_EEPROM                242
 
 #endif // cyclop_plus_osd_h

--- a/src/cyclop_plus_plus/cyclop_plus_plus.h
+++ b/src/cyclop_plus_plus/cyclop_plus_plus.h
@@ -47,6 +47,7 @@
 #define F_BAND_OPTION             10
 #define R_BAND_OPTION             11
 #define L_BAND_OPTION             12
+#define BATTERY_TEXT_OPTION       13
 
 #define BATTERY_ALARM_DEFAULT     1   /* On    */
 #define ALARM_LEVEL_DEFAULT       5   /* value 1-8   */
@@ -61,13 +62,14 @@
 #define F_BAND_DEFAULT            1   /* On */
 #define R_BAND_DEFAULT            1   /* On */
 #define L_BAND_DEFAULT            1   /* On */
+#define BATTERY_TEXT_DEFAULT      0   /* Off */
 
-#define MAX_OPTIONS               13
+#define MAX_OPTIONS               14
 
 // User Configuration Commands
-#define TEST_ALARM_COMMAND        13
-#define RESET_SETTINGS_COMMAND    14
-#define EXIT_COMMAND              15
+#define TEST_ALARM_COMMAND        14
+#define RESET_SETTINGS_COMMAND    15
+#define EXIT_COMMAND              16
 #define MAX_COMMANDS              3
 
 // Number of lines in configuration menu

--- a/src/cyclop_plus_plus/cyclop_plus_plus.h
+++ b/src/cyclop_plus_plus/cyclop_plus_plus.h
@@ -48,6 +48,8 @@
 #define R_BAND_OPTION             11
 #define L_BAND_OPTION             12
 #define BATTERY_TEXT_OPTION       13
+#define OFFSET_X_OPTION           14
+#define OFFSET_Y_OPTION           15
 
 #define BATTERY_ALARM_DEFAULT     1   /* On    */
 #define ALARM_LEVEL_DEFAULT       5   /* value 1-8   */
@@ -63,14 +65,17 @@
 #define R_BAND_DEFAULT            1   /* On */
 #define L_BAND_DEFAULT            1   /* On */
 #define BATTERY_TEXT_DEFAULT      0   /* Off */
+#define OFFSET_X_DEFAULT          0   /* 0 pixels */
+#define OFFSET_Y_DEFAULT          0   /* 0 pixels */
 
-#define MAX_OPTIONS               14
+#define MAX_OPTIONS               16
 
 // User Configuration Commands
-#define TEST_ALARM_COMMAND        14
-#define RESET_SETTINGS_COMMAND    15
-#define EXIT_COMMAND              16
-#define MAX_COMMANDS              3
+#define TEST_ALARM_COMMAND        16
+#define RESET_SETTINGS_COMMAND    17
+#define SET_OFFSET_COMMAND        18
+#define EXIT_COMMAND              19
+#define MAX_COMMANDS              4
 
 // Number of lines in configuration menu
 #define MAX_OPTION_LINES          9

--- a/src/cyclop_plus_plus/cyclop_plus_plus.h
+++ b/src/cyclop_plus_plus/cyclop_plus_plus.h
@@ -139,6 +139,6 @@
 // Release information
 #define VER_DATE_STRING           "2017-03-13"
 #define VER_INFO_STRING           "v2.3 by Dvogonen"
-#define VER_EEPROM                240
+#define VER_EEPROM                241
 
 #endif // cyclop_plus_osd_h

--- a/src/cyclop_plus_plus/cyclop_plus_plus.ino
+++ b/src/cyclop_plus_plus/cyclop_plus_plus.ino
@@ -104,7 +104,7 @@
 
 unsigned int  autoScan( unsigned int frequency );
 unsigned int  averageAnalogRead( unsigned char pin );
-void          batteryMeter(unsigned char x, unsigned char y, bool showNumbers = false);
+void          batteryMeter(unsigned char x, unsigned char y);
 unsigned char bestChannelMatch( unsigned int frequency );
 void          buttonPressInterrupt();
 void          drawAutoScanScreen(void);
@@ -695,7 +695,7 @@ unsigned int getVoltage( void )
 //******************************************************************************
 //* function: batteryMeter
 //******************************************************************************
-void batteryMeter( unsigned char x, unsigned char y, bool showNumbers )
+void batteryMeter( unsigned char x, unsigned char y )
 {
   unsigned int voltage;
   unsigned char value;
@@ -741,7 +741,7 @@ void batteryMeter( unsigned char x, unsigned char y, bool showNumbers )
     alarmOnPeriod = 0;
     alarmOffPeriod = 0;
   }
-  drawBattery(x, y, value, showNumbers);
+  drawBattery(x, y, value, options[BATTERY_TEXT_OPTION]);
 }
 
 //******************************************************************************
@@ -798,6 +798,7 @@ void resetOptions(void) {
   options[F_BAND_OPTION]           = F_BAND_DEFAULT;
   options[R_BAND_OPTION]           = R_BAND_DEFAULT;
   options[L_BAND_OPTION]           = L_BAND_DEFAULT;
+  options[BATTERY_TEXT_OPTION]     = BATTERY_TEXT_DEFAULT;
 
   updateSoftPositions();
 }
@@ -1247,6 +1248,7 @@ void drawOptionsScreen(unsigned char option, unsigned char in_edit_state ) {
       case F_BAND_OPTION:            osd_string("fatshark band      "); break;
       case R_BAND_OPTION:            osd_string("race band          "); break;
       case L_BAND_OPTION:            osd_string("low band           "); break;
+      case BATTERY_TEXT_OPTION:      osd_string("show bat percentage"); break;
       case RESET_SETTINGS_COMMAND:   osd_string("reset settings     "); break;
       case TEST_ALARM_COMMAND:       osd_string("test alarm         "); break;
       case EXIT_COMMAND:             osd_string("exit               "); break;
@@ -1275,6 +1277,7 @@ void drawOptionsScreen(unsigned char option, unsigned char in_edit_state ) {
         case F_BAND_OPTION:           osd_string(options[j] ? "on     " : "off    "); break;
         case R_BAND_OPTION:           osd_string(options[j] ? "on     " : "off    "); break;
         case L_BAND_OPTION:           osd_string(options[j] ? "on     " : "off    "); break;
+        case BATTERY_TEXT_OPTION:     osd_string(options[j] ? "on     " : "off    "); break;
       }
     }
     else

--- a/src/minimosd_for_cyclop/minimosd_for_cyclop.ino
+++ b/src/minimosd_for_cyclop/minimosd_for_cyclop.ino
@@ -1803,6 +1803,8 @@ const char tableOfAllCharacters[13824] PROGMEM = {
 #define CMD_NEWLINE         13  /* Moves cursor to start of the next line      */
 #define CMD_SET_X           14  /* Position X cursor (next char is a parameter)*/
 #define CMD_SET_Y           15  /* Position Y cursor (next char is a parameter)*/
+#define CMD_SET_OFFSET      16  /* Display Offset XY cursor (next 2 chars are parameters)*/
+
 /*******************************************************************************
    Hardware Defines
  *******************************************************************************/
@@ -1980,6 +1982,10 @@ void loop()
   static bool activeCommand = false;
   static bool waitingForX = false;
   static bool waitingForY = false;
+  static bool waitingForOffsetX = false;
+  static bool waitingForOffsetY = false;
+  static byte offsetX = 0;
+  static byte offsetY = 0;
   long videoUpdateTimer = 0;
   unsigned char inChar;
 
@@ -2007,6 +2013,7 @@ void loop()
           case CMD_NEWLINE:           newLine(); break;
           case CMD_SET_X:             waitingForX = true; break;
           case CMD_SET_Y:             waitingForY = true; break;
+          case CMD_SET_OFFSET:        waitingForOffsetX = true; break;
           default: break;           // Unknown command - Just skip it
         }
         activeCommand = false;
@@ -2018,6 +2025,16 @@ void loop()
       else if (waitingForY) {
         curY = inChar;
         waitingForY = false;
+      }
+      else if (waitingForOffsetX) {
+        offsetX = inChar;
+        waitingForOffsetX = false;
+        waitingForOffsetY = true;
+      }
+      else if (waitingForOffsetY) {
+        offsetY = inChar;
+        waitingForOffsetY = false;
+        osd.setDisplayOffsets(offsetX, offsetY);
       }
       else {
         osd.printMax7456Char( fillState && (inChar > 31) && (inChar < 128) ? inChar + 0x80 : inChar, curX++, curY, blinkState, inverseState );


### PR DESCRIPTION
This adds an option for setting disply x and y offsets. I have the problem that in the graphic scanner the lowest line is invisible (i don't see the x scale). When recording with the dvr i can see maybe 1/4 of the top of those characters in the scale line. I have no idea if those offsets work in the correct direction but saw the function in the OSD driver.

This is untested and based on the PR #10 (which would need to be merged first before this one can be merged).

I plan to test all those 3 PRs and report back or update them accordingly.