### PR TITLE
[cyclops_plus_plus] - ensure that max alarm level doesn't exceed the …

### DIFF
--- a/src/cyclop_plus_plus/cyclop_plus_plus.ino
+++ b/src/cyclop_plus_plus/cyclop_plus_plus.ino
@@ -352,7 +352,7 @@ void loop()
     if (millis() > alarmTimer) {
       alarmSoundOn = !alarmSoundOn;
       if (alarmSoundOn) {
-        analogWrite( ALARM_PIN, 1 << options[ALARM_LEVEL_OPTION] );
+        analogWrite( ALARM_PIN, (1 << options[ALARM_LEVEL_OPTION]) - 1 );
         alarmTimer = millis() + alarmOnPeriod;
       }
       else {
@@ -910,7 +910,7 @@ void testAlarm( void ) {
 
   while (getClickType(BUTTON_PIN) == NO_CLICK) {
     for (i = 0; i < 3; i++) {
-      analogWrite( ALARM_PIN, 1 << options[ALARM_LEVEL_OPTION] );
+      analogWrite( ALARM_PIN, (1 << options[ALARM_LEVEL_OPTION]) - 1 );
       delay(ALARM_MAX_ON);
       analogWrite( ALARM_PIN, 0 );
       delay(ALARM_MAX_OFF);


### PR DESCRIPTION
…maximum allowed dutycycle (255).

This fixes issue #8 

1 << 8 is 256 - max allowed dutycycle is 255

the prototype of analogWrite is:

void analogWrite(uint8_t, int);

So it takes an signed int as dutrycycle parameter. Because of the int it doesn't rollover to 0 but to 1 maybe.
